### PR TITLE
Localized dynamic navigation

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -1,5 +1,7 @@
 VITE_ENVIRONMENT_ID=
 VITE_DELIVERY_API_KEY=
+# (Optional) used for building dynamic navigation based on the landing page from the specific collection
+VITE_COLLECTION=patient_resources
 
 # (Optional) used only for model generation
 VITE_MANAGEMENT_API_KEY=

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -1,11 +1,45 @@
 import { FC } from "react";
-import { NavLink, useParams, useSearchParams } from "react-router";
-import { createPreviewLink } from "../utils/link";
+import { NavLink, useSearchParams } from "react-router";
+import { createClient } from "../utils/client";
+import { CollectionCodenames, LandingPage, LanguageCodenames } from "../model";
+import { DeliveryError } from "@kontent-ai/delivery-sdk";
+import { useSuspenseQueries } from "@tanstack/react-query";
+import { useAppContext } from "../context/AppContext";
 
 const Navigation: FC = () => {
-  const { envId } = useParams();
+  const { environmentId, apiKey, collection } = useAppContext();
   const [searchParams] = useSearchParams();
   const isPreview = searchParams.get("preview") === "true";
+
+  const lang = searchParams.get("lang");
+  const collectionParam = searchParams.get("collection")
+  const collectionFilter = collectionParam ?? collection ?? "patient_resources";
+
+  const [navigation] = useSuspenseQueries({
+    queries: [
+      {
+        queryKey: ["navigation"],
+        queryFn: () =>
+          createClient(environmentId, apiKey, isPreview)
+            .items<LandingPage>()
+            .type("landing_page")
+            .limitParameter(1)
+            .languageParameter((lang ?? "default") as LanguageCodenames)
+            .collections([collectionFilter as CollectionCodenames])
+            .toPromise()
+            .then(res => res.data.items[0]?.elements.subpages.linkedItems.map(subpage => ({
+              name: subpage.elements.headline.value,
+              link: subpage.elements.url.value,
+            })))
+            .catch((err) => {
+              if (err instanceof DeliveryError) {
+                return null;
+              }
+              throw err;
+            }),
+      },
+    ],
+  });
 
   const createMenuLink = (name: string, link: string) => (
     <li key={name}>
@@ -16,11 +50,9 @@ const Navigation: FC = () => {
   return (
     <nav>
       <menu className="flex flex-col lg:flex-row gap-5 lg:gap-[60px] items-center list-none">
-        {createMenuLink("Home", createPreviewLink(envId ? `/envid/${envId}` : "/", isPreview))}
-        {createMenuLink("Services", createPreviewLink(envId ? `/envid/${envId}/services` : "/services", isPreview))}
-        {createMenuLink("Our Team", createPreviewLink(envId ? `/envid/${envId}/our-team` : "/our-team", isPreview))}
-        {createMenuLink("Research", createPreviewLink(envId ? `/envid/${envId}/research` : "/research", isPreview))}
-        {createMenuLink("Blog", createPreviewLink(envId ? `/envid/${envId}/blog` : "/blog", isPreview))}
+        {
+          navigation.data?.map(({ name, link }) => createMenuLink(name, link))
+        }
       </menu>
     </nav>
   );

--- a/src/context/AppContext.tsx
+++ b/src/context/AppContext.tsx
@@ -1,17 +1,17 @@
-import { useAuth0 } from "@auth0/auth0-react";
 import { useSuspenseQuery } from "@tanstack/react-query";
 import { createContext, FC, PropsWithChildren, useContext } from "react";
 import { useParams } from "react-router-dom";
-import { loadPreviewApiKey } from "../utils/api";
 
 type AppContext = {
   environmentId: string;
   apiKey: string;
+  collection: string;
 };
 
 const defaultAppContext: AppContext = {
   environmentId: import.meta.env.VITE_ENVIRONMENT_ID!,
   apiKey: import.meta.env.VITE_DELIVERY_API_KEY!,
+  collection: import.meta.env.VITE_COLLECTION!,
 };
 
 const AppContext = createContext<AppContext>(defaultAppContext);
@@ -20,7 +20,6 @@ export const useAppContext = () => useContext(AppContext);
 
 export const AppContextComponent: FC<PropsWithChildren> = ({ children }) => {
   const { envId } = useParams();
-  const { getAccessTokenSilently, loginWithRedirect } = useAuth0();
 
   const contextData = useSuspenseQuery({
     queryKey: [`env-data${envId ? `-${envId}` : ""}`],
@@ -28,29 +27,11 @@ export const AppContextComponent: FC<PropsWithChildren> = ({ children }) => {
       if (!envId) {
         return defaultAppContext;
       }
-      return getAccessTokenSilently()
-        .then(res => {
-          return loadPreviewApiKey({
-            accessToken: res,
-            environmentId: envId,
-          });
-        })
-        .then(res => {
-          if (!res) {
-            throw new Error("Could not obtain preview API KEY");
-          }
-
-          return { environmentId: envId, apiKey: res };
-        })
-        .catch(err => {
-          if (err.error === "login_required") {
-            loginWithRedirect();
-          }
-          if (err.error === "consent_required") {
-            loginWithRedirect();
-          }
-          throw err;
-        });
+      return {
+        environmentId: envId,
+        apiKey: import.meta.env.VITE_DELIVERY_API_KEY!,
+        collection: import.meta.env.VITE_COLLECTION!,
+      };
     },
   });
 


### PR DESCRIPTION
### Motivation

Creating a dynamic and localized navigation based on the backlog item: https://app.asana.com/1/1204058094034299/project/1209824635417149/task/1210111207621098?focus=true

### Checklist

- [x] Code follows coding conventions held in this repo
- [n/a] Automated tests have been added
- [n/a] Tests are passing
- [x] Docs have been updated (if applicable)
- [x] Temporary settings (e.g. variables used during development and testing) have been reverted to defaults

### How to test

You can test the setup by changing the subpage under the landing page.
It’s also possible to create an additional landing page in a different collection. This allows you to build a mini sub-site with its own navigation.

Be sure to add the following environment variable:
VITE_COLLECTION=patient_resources

This variable sets the default collection for the navigation. The landing page will be retrieved from this collection by default.